### PR TITLE
Backup reviews at checkpoints

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -1,1 +1,3 @@
 AMAZON_BASE_URL = 'https://www.amazon.com'
+CACHE_FILE='cache.json'
+CACHE_CHECK=50 # backup at set checkpoint

--- a/core_extract_comments.py
+++ b/core_extract_comments.py
@@ -2,8 +2,9 @@ import logging
 import math
 import re
 import textwrap
+import json
 
-from constants import AMAZON_BASE_URL
+from constants import AMAZON_BASE_URL, CACHE_FILE, CACHE_CHECK
 from core_utils import get_soup, persist_comment_to_disk
 
 
@@ -53,6 +54,7 @@ def get_comments_with_product_id(product_id):
     max_page_number *= 0.1  # displaying 10 results per page. So if 663 results then ~66 pages.
     max_page_number = math.ceil(max_page_number)
 
+    rev_count = 0
     for page_number in range(1, max_page_number + 1):
         if page_number > 1:
             product_reviews_link = get_product_reviews_url(product_id, page_number)
@@ -103,6 +105,12 @@ def get_comments_with_product_id(product_id):
                             'review_url': review_url,
                             'review_date': review_date,
                            })
+            rev_count += 1
+            if (rev_count == CACHE_CHECK):
+                with open(CACHE_FILE, 'w', encoding='utf-8') as fp:
+                    json.dump(reviews, fp, sort_keys=True, indent=4,
+                              ensure_ascii=False)
+                rev_count = 0
     return reviews
 
 


### PR DESCRIPTION
Tweaked get comments function to back up the whole review list at certain checkpoints.
For now this is very inefficient but does the job.

Next step can be to replace get comment with a generator and catch interrupts in the main run function.